### PR TITLE
Issue 1 responsive video sizing

### DIFF
--- a/apps/qubit/modules/digitalobject/templates/_showVideo.php
+++ b/apps/qubit/modules/digitalobject/templates/_showVideo.php
@@ -11,7 +11,7 @@
 <?php elseif ($usageType == QubitTerm::REFERENCE_ID): ?>
 
   <?php if ($showFlashPlayer): ?>
-    <video style="width:100%;height:100%;" width="100%" height="100%" preload="metadata" class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></video>
+    <video width="480" height="360" preload="metadata" class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></video>
   <?php else: ?>
     <div style="text-align: center">
       <?php echo image_tag($representation->getFullPath(), array('style' => 'border: #999 1px solid', 'alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>

--- a/apps/qubit/modules/digitalobject/templates/_showVideo.php
+++ b/apps/qubit/modules/digitalobject/templates/_showVideo.php
@@ -11,7 +11,7 @@
 <?php elseif ($usageType == QubitTerm::REFERENCE_ID): ?>
 
   <?php if ($showFlashPlayer): ?>
-    <video width="480" height="360" preload="metadata" class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></video>
+    <video style="width:100%;height:100%;" width="100%" height="100%" preload="metadata" class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></video>
   <?php else: ?>
     <div style="text-align: center">
       <?php echo image_tag($representation->getFullPath(), array('style' => 'border: #999 1px solid', 'alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>

--- a/apps/qubit/modules/digitalobject/templates/_showVideo.php
+++ b/apps/qubit/modules/digitalobject/templates/_showVideo.php
@@ -11,7 +11,7 @@
 <?php elseif ($usageType == QubitTerm::REFERENCE_ID): ?>
 
   <?php if ($showFlashPlayer): ?>
-    <video style="width:100%;height:100%;" width="100%" height="100%" preload="metadata" class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></video>
+    <video style="max-width:100%;" preload="metadata" class="mediaelement-player" src="<?php echo public_path($representation->getFullPath()) ?>"></video>
   <?php else: ?>
     <div style="text-align: center">
       <?php echo image_tag($representation->getFullPath(), array('style' => 'border: #999 1px solid', 'alt' => __($resource->getDigitalObjectAltText() ?: 'Original %1% not accessible', array('%1%' => sfConfig::get('app_ui_label_digitalobject'))))) ?>


### PR DESCRIPTION
<h2>Testing</h2>

- [x] Chrome
- - [x] 1920x1080
- - [x] 1920x800
- - [x] 720x480
- - [x] 320x240
- [x] Chrome mobile
- - [x] 1920x1080
- - [x] 1920x800
- - [x] 720x480
- - [x] 320x240
- [x] Edge
- - [x] 1920x1080
- - [x] 1920x800
- - [x] 720x480
- - [x] 320x240
- [x] Safari
- - [x] 1920x1080
- - [x] 1920x800
- - [x] 720x480
- - [x] 320x240
- [x] Safari mobile
- - [x] 1920x1080
- - [x] 1920x800
- - [x] 720x480
- - [x] 320x240
- [x] IE11
- - [x] 1920x1080
- - [x] 1920x800
- - [x] 720x480
- - [x] 320x240
- [x] Firefox
- - [x] 1920x1080
- - [x] 1920x800
- - [x] 720x480
- - [x] 320x240

<h2>Observations</h2>
Video both shrinks and stretches. Buggy or no functionality IE9 or earlier, but this is true for mediaelement in general.